### PR TITLE
[SPT-37663] Add domain to regioncards

### DIFF
--- a/src/app/status-card/status-card.component.html
+++ b/src/app/status-card/status-card.component.html
@@ -7,6 +7,9 @@
       <div class="card-title">
         {{ region().name }}
       </div>
+      <div class="card-domain">
+        {{ region().appdomain }}
+      </div>
       <div class="indicator" [ngClass]="getIndicatorClass()">
         {{ status()?.description }}
       </div>

--- a/src/app/status-card/status-card.component.html
+++ b/src/app/status-card/status-card.component.html
@@ -1,8 +1,12 @@
 <div class="card-body">
   <div class="card-contents">
-    <div class="card-title">
-      <img class="card-icon" src="assets/world.svg" />
-      {{ region().name }}
+    <div class="card-icon">
+      <img src="assets/world.svg" />
+    </div>
+    <div>
+      <div class="card-title">
+        {{ region().name }}
+      </div>
       <div class="indicator" [ngClass]="getIndicatorClass()">
         {{ status()?.description }}
       </div>

--- a/src/app/status-card/status-card.component.scss
+++ b/src/app/status-card/status-card.component.scss
@@ -15,9 +15,13 @@
 }
 
 .card-contents {
+  width: 100%;
   margin-top: auto;
   margin-bottom: auto;
   padding: 0 40px;
+  flex-grow: 1;
+  display: flex;
+  align-items: stretch;
 }
 
 .card-title {
@@ -29,9 +33,10 @@
 }
 
 .card-icon {
-  position: relative;
+  float: left;
   margin-right: 5px;
   top: 9px;
+  flex-grow: 0;
 }
 
 .indicator {
@@ -44,9 +49,8 @@
   width: fit-content;
   height: fit-content;
   padding: 8px 10px;
+  margin-top: 8px;
   border-radius: 6px;
-  margin-top: 12px;
-  margin-left: 46px;
 
   &-none {
     background-color: #1d813a;

--- a/src/app/status-card/status-card.component.scss
+++ b/src/app/status-card/status-card.component.scss
@@ -32,6 +32,14 @@
   color: black;
 }
 
+.card-domain {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 17px;
+  letter-spacing: normal;
+  color: gray;
+}
+
 .card-icon {
   float: left;
   margin-right: 5px;

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,34 +31,42 @@ export const regions: Array<Region> = [
   {
     name: 'Americas (US East)',
     url: 'https://useast.swimlanestatus.com',
+    appdomain: 'us1.swimlane.app',
   },
   {
     name: 'Americas (US East 2)',
     url: 'https://useast2.swimlanestatus.com',
+    appdomain: 'us2.swimlane.app',
   },
   {
     name: 'Americas (US West)',
     url: 'https://uswest.swimlanestatus.com',
+    appdomain: 'usn.swimlane.app',
   },
   {
     name: 'Asia Pacific (Australia)',
     url: 'https://australia.swimlanestatus.com',
+    appdomain: 'au1.swimlane.app',
   },
   {
     name: 'Asia Pacific (Japan)',
     url: 'https://japan.swimlanestatus.com',
+    appdomain: 'jp1.swimlane.app',
   },
   {
     name: 'Asia Pacific (Singapore)',
     url: 'https://singapore.swimlanestatus.com',
+    appdomain: 'sg1.swimlane.app',
   },
   {
     name: 'Europe (Germany)',
     url: 'https://germany.swimlanestatus.com',
+    appdomain: 'de1.swimlane.app',
   },
   {
     name: 'Europe (UK)',
     url: 'https://uk.swimlanestatus.com',
+    appdomain: 'uk1.swimlane.app',
   },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type Region = {
   name: string;
   url: string;
+  appdomain: string;
   status?: Status;
 };
 


### PR DESCRIPTION
This update adds a new `appdomain` field to the type definition for regions, and displays the content of that field under the region name in the status cards.

It also reworks the card's HTML and CSS so that the positioning is _layout-based_ rather than manual positioning using margins and spacing.

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/b02e978a-5ac1-467d-b835-aba3f05e837f" />
